### PR TITLE
feat: add multiple themes and URL theme parameter

### DIFF
--- a/client/app/components/ThemeProvider.tsx
+++ b/client/app/components/ThemeProvider.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { createContext, useContext, useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+
+type Theme = 'vanilla' | 'dark' | 'neon' | 'nature';
+
+interface ThemeContextType {
+  theme: Theme;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const searchParams = useSearchParams();
+  const [theme, setTheme] = useState<Theme>('vanilla');
+
+  useEffect(() => {
+    const themeParam = searchParams.get('theme') as Theme;
+    if (themeParam && ['vanilla', 'dark', 'neon', 'nature'].includes(themeParam)) {
+      setTheme(themeParam);
+    }
+  }, [searchParams]);
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}

--- a/client/app/globals.css
+++ b/client/app/globals.css
@@ -2,9 +2,52 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Base theme (vanilla) */
 :root {
   --background: #ffffff;
   --foreground: #171717;
+}
+
+/* Dark theme */
+[data-theme='dark'] {
+  --background: #0a0a0a;
+  --foreground: #ededed;
+  --board-bg: #1a1a1a;
+  --square-bg: #262626;
+  --square-border: #404040;
+  --x-color: #60a5fa;
+  --o-color: #f87171;
+  --hover-bg: #333333;
+}
+
+/* Neon theme */
+[data-theme='neon'] {
+  --background: #000000;
+  --foreground: #ffffff;
+  --board-bg: #0c0c0c;
+  --square-bg: #1a1a1a;
+  --square-border: #00ff00;
+  --x-color: #00ffff;
+  --o-color: #ff00ff;
+  --hover-bg: #2a2a2a;
+}
+
+/* Nature theme */
+[data-theme='nature'] {
+  --background: #e6f0e6;
+  --foreground: #2c4a2c;
+  --board-bg: #ffffff;
+  --square-bg: #f0f7f0;
+  --square-border: #4a7c4a;
+  --x-color: #2d5a27;
+  --o-color: #8b4513;
+  --hover-bg: #d1e7d1;
+}
+
+body {
+  color: var(--foreground);
+  background: var(--background);
+  font-family: Arial, Helvetica, sans-serif;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -14,10 +57,39 @@
   }
 }
 
-body {
-  color: var(--foreground);
-  background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
+[data-theme='neon'] body {
+  background: linear-gradient(135deg, #000000 0%, #1a1a1a 100%);
+  position: relative;
+}
+
+[data-theme='neon'] body::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: 
+    radial-gradient(circle at 20% 20%, rgba(0, 255, 255, 0.1) 0%, transparent 20%),
+    radial-gradient(circle at 80% 80%, rgba(255, 0, 255, 0.1) 0%, transparent 20%),
+    radial-gradient(circle at 50% 50%, rgba(0, 255, 0, 0.1) 0%, transparent 40%);
+  pointer-events: none;
+}
+
+[data-theme='nature'] body {
+  background-image: url('/nature-bg.svg');
+  position: relative;
+}
+
+[data-theme='nature'] body::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient(135deg, rgba(255,255,255,0.1) 0%, transparent 100%);
+  pointer-events: none;
 }
 
 html, body {

--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { MusicProvider } from "./context/MusicContext";
+import { ThemeProvider } from "./components/ThemeProvider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -28,9 +29,11 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-       <MusicProvider>
-          {children}
-        </MusicProvider>
+        <ThemeProvider>
+          <MusicProvider>
+            {children}
+          </MusicProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/client/app/play/components/GameBoard.tsx
+++ b/client/app/play/components/GameBoard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { motion } from 'framer-motion';
 import Square from './Square';
+import { useTheme } from '../../components/ThemeProvider';
 
 interface GameBoardProps {
   squares: (string | null)[];
@@ -8,21 +9,45 @@ interface GameBoardProps {
   winner?: { line?: number[] } | null;
 }
 
-const GameBoard: React.FC<GameBoardProps> = ({ squares, onClick, winner }) => (
-  <motion.div
-    className="grid grid-cols-3 gap-2 mb-8"
-    initial={{ scale: 0.8, opacity: 0 }}
-    animate={{ scale: 1, opacity: 1 }}
-  >
-    {squares.map((square, i) => (
-      <Square
-        key={i}
-        value={square}
-        onClick={() => onClick(i)}
-        winningSquare={winner?.line?.includes(i) ?? false}
-      />
-    ))}
-  </motion.div>
-);
+const GameBoard: React.FC<GameBoardProps> = ({ squares, onClick, winner }) => {
+  const { theme } = useTheme();
+
+  const getBoardStyles = () => {
+    if (theme === 'vanilla') {
+      return {
+        className: "grid grid-cols-3 gap-2 mb-8",
+        style: {}
+      };
+    }
+
+    return {
+      className: "grid grid-cols-3 gap-2 mb-8 p-4 rounded-lg",
+      style: {
+        backgroundColor: 'var(--board-bg)',
+        boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)'
+      }
+    };
+  };
+
+  const boardStyles = getBoardStyles();
+
+  return (
+    <motion.div
+      className={boardStyles.className}
+      style={boardStyles.style}
+      initial={{ scale: 0.8, opacity: 0 }}
+      animate={{ scale: 1, opacity: 1 }}
+    >
+      {squares.map((square, i) => (
+        <Square
+          key={i}
+          value={square}
+          onClick={() => onClick(i)}
+          winningSquare={winner?.line?.includes(i) ?? false}
+        />
+      ))}
+    </motion.div>
+  );
+};
 
 export default GameBoard;

--- a/client/app/play/components/GameStatus.tsx
+++ b/client/app/play/components/GameStatus.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
+import { useTheme } from '../../components/ThemeProvider';
 
 interface GameStatusProps {
   winner?: { winner?: string } | null;
@@ -13,34 +14,77 @@ const GameStatus: React.FC<GameStatusProps> = ({
   isDraw, 
   xIsNext, 
   showWinnerAlert 
-}) => (
-  <>
-    <AnimatePresence mode="wait">
-      {showWinnerAlert && (
-        <motion.div
-          initial={{ opacity: 0, scale: 0.8 }}
-          animate={{ opacity: 1, scale: 1 }}
-          exit={{ opacity: 0, scale: 0.8 }}
-          className="bg-orange-500 dark:bg-red-600 text-gray-800 dark:text-gray-100 py-2 px-4 rounded-lg mb-4 font-bold text-lg shadow-lg"
-        >
-          {showWinnerAlert}
-        </motion.div>
-      )}
-    </AnimatePresence>
+}) => {
+  const { theme } = useTheme();
 
-    <motion.div
-      className="h-8 text-xl text-gray-100"
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      key={winner?.winner || isDraw ? "result" : "next"}
-    >
-      {winner
-        ? `Winner: ${winner.winner}`
-        : isDraw
-        ? "Draw!"
-        : `Next player: ${xIsNext ? "X" : "O"}`}
-    </motion.div>
-  </>
-);
+  const getAlertStyles = () => {
+    if (theme === 'vanilla') {
+      return {
+        className: "bg-orange-500 dark:bg-red-600 text-gray-800 dark:text-gray-100 py-2 px-4 rounded-lg mb-4 font-bold text-lg shadow-lg",
+        style: {}
+      };
+    }
+
+    return {
+      className: "py-2 px-4 rounded-lg mb-4 font-bold text-lg shadow-lg",
+      style: {
+        backgroundColor: 'var(--board-bg)',
+        color: 'var(--foreground)',
+        border: '1px solid var(--square-border)'
+      }
+    };
+  };
+
+  const getStatusStyles = () => {
+    if (theme === 'vanilla') {
+      return {
+        className: "h-8 text-xl text-gray-800 dark:text-gray-100",
+        style: {}
+      };
+    }
+
+    return {
+      className: "h-8 text-xl",
+      style: {
+        color: 'var(--foreground)'
+      }
+    };
+  };
+
+  const alertStyles = getAlertStyles();
+  const statusStyles = getStatusStyles();
+
+  return (
+    <>
+      <AnimatePresence mode="wait">
+        {showWinnerAlert && (
+          <motion.div
+            initial={{ opacity: 0, scale: 0.8 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.8 }}
+            className={alertStyles.className}
+            style={alertStyles.style}
+          >
+            {showWinnerAlert}
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      <motion.div
+        className={statusStyles.className}
+        style={statusStyles.style}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        key={winner?.winner || isDraw ? "result" : "next"}
+      >
+        {winner
+          ? `Winner: ${winner.winner}`
+          : isDraw
+          ? "Draw!"
+          : `Next player: ${xIsNext ? "X" : "O"}`}
+      </motion.div>
+    </>
+  );
+};
 
 export default GameStatus;

--- a/client/app/play/components/Square.tsx
+++ b/client/app/play/components/Square.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { motion } from 'framer-motion';
+import { useTheme } from '../../components/ThemeProvider';
 
 interface SquareProps {
   value: string | null;
@@ -7,34 +8,78 @@ interface SquareProps {
   winningSquare: boolean;
 }
 
-const Square: React.FC<SquareProps> = ({ value, onClick, winningSquare }) => (
-  <motion.button
-    onClick={onClick}
-    className={`w-20 h-20 md:w-24 md:h-24 border-4 text-4xl font-bold flex items-center justify-center rounded-lg shadow-lg
-      ${
-        winningSquare
-          ? "bg-yellow-300 border-yellow-500 text-orange-700 dark:bg-gray-900 dark:border-slate-300 dark:text-orange-200"
-          : "bg-white border-orange-500 hover:bg-orange-100 dark:bg-[#0a192f] dark:border-red-700 dark:hover:bg-gray-800"
-      }`}
-    whileHover={{ scale: 1.05 }}
-    whileTap={{ scale: 0.95 }}
-    initial={{ opacity: 0 }}
-    animate={{ opacity: 1 }}
-  >
-    {value && (
-      <motion.span
-        initial={{ scale: 0, rotate: -180 }}
-        animate={{ scale: 1, rotate: 0 }}
-        className={
-          value === "X"
-            ? "text-blue-600 dark:text-blue-400"
-            : "text-red-600 dark:text-red-400"
-        }
-      >
-        {value}
-      </motion.span>
-    )}
-  </motion.button>
-);
+const Square: React.FC<SquareProps> = ({ value, onClick, winningSquare }) => {
+  const { theme } = useTheme();
+
+  const getSquareStyles = () => {
+    if (theme === 'vanilla') {
+      return {
+        className: `w-20 h-20 md:w-24 md:h-24 border-4 text-4xl font-bold flex items-center justify-center rounded-lg shadow-lg ${
+          winningSquare
+            ? "bg-yellow-300 border-yellow-500 text-orange-700 dark:bg-gray-900 dark:border-slate-300 dark:text-orange-200"
+            : "bg-white border-orange-500 hover:bg-orange-100 dark:bg-[#0a192f] dark:border-red-700 dark:hover:bg-gray-800"
+        }`,
+        style: {}
+      };
+    }
+
+    return {
+      className: "w-20 h-20 md:w-24 md:h-24 text-4xl font-bold flex items-center justify-center rounded-lg",
+      style: {
+        backgroundColor: winningSquare ? 'var(--hover-bg)' : 'var(--square-bg)',
+        border: `4px solid ${winningSquare ? 'var(--x-color)' : 'var(--square-border)'}`,
+        color: 'var(--foreground)',
+        boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)'
+      }
+    };
+  };
+
+  const getSymbolStyles = () => {
+    if (theme === 'vanilla') {
+      return {
+        className: value === "X"
+          ? "text-blue-600 dark:text-blue-400"
+          : "text-red-600 dark:text-red-400",
+        style: {}
+      };
+    }
+
+    return {
+      className: "",
+      style: {
+        color: value === 'X' ? 'var(--x-color)' : 'var(--o-color)'
+      }
+    };
+  };
+
+  const squareStyles = getSquareStyles();
+  const symbolStyles = getSymbolStyles();
+
+  return (
+    <motion.button
+      onClick={onClick}
+      className={squareStyles.className}
+      style={squareStyles.style}
+      whileHover={theme === 'vanilla' ? { scale: 1.05 } : {
+        scale: 1.05,
+        backgroundColor: 'var(--hover-bg)'
+      }}
+      whileTap={{ scale: 0.95 }}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+    >
+      {value && (
+        <motion.span
+          initial={{ scale: 0, rotate: -180 }}
+          animate={{ scale: 1, rotate: 0 }}
+          className={symbolStyles.className}
+          style={symbolStyles.style}
+        >
+          {value}
+        </motion.span>
+      )}
+    </motion.button>
+  );
+};
 
 export default Square;

--- a/client/app/play/page.tsx
+++ b/client/app/play/page.tsx
@@ -2,11 +2,10 @@
 
 import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
-import { Moon, Sun } from "lucide-react";
-// import Square from './Square';
 import GameBoard from './components/GameBoard';
 import GameScores from './components/GameScores';
 import GameStatus from './components/GameStatus';
+import { useTheme } from '../components/ThemeProvider';
 
 const TicTacToe = () => {
   const [squares, setSquares] = useState<(string | null)[]>(
@@ -15,8 +14,8 @@ const TicTacToe = () => {
   const [xIsNext, setXIsNext] = useState(true);
   const [xScore, setXScore] = useState(0);
   const [oScore, setOScore] = useState(0);
-  const [isDarkMode, setIsDarkMode] = useState(false);
   const [showWinnerAlert, setShowWinnerAlert] = useState<string | null>(null);
+  const { theme } = useTheme();
 
   const calculateWinner = (squares: (string | null)[]) => {
     const lines = [
@@ -72,20 +71,11 @@ const TicTacToe = () => {
     setShowWinnerAlert(null);
   };
 
-  const toggleTheme = () => {
-    setIsDarkMode(!isDarkMode);
-    document.documentElement.classList.toggle("dark");
-  };
-
   useEffect(() => {
     const prefersDark = window.matchMedia(
       "(prefers-color-scheme: dark)"
     ).matches;
-    setIsDarkMode(prefersDark);
-
-    if (prefersDark) {
-      document.documentElement.classList.add("dark");
-    }
+    document.documentElement.classList.toggle("dark", prefersDark);
   }, []);
 
   useEffect(() => {
@@ -94,12 +84,66 @@ const TicTacToe = () => {
     return () => clearTimeout(timeout);
   }, [showWinnerAlert]);
 
+  const getContainerStyles = () => {
+    if (theme === 'vanilla') {
+      return {
+        className: "bg-gradient-to-br from-orange-300 via-amber-300 to-yellow-400 dark:from-[#0a192f] dark:via-[#0a192f] dark:to-[#112240] text-gray-900 dark:text-gray-100 transition-colors duration-300 min-h-screen",
+        style: {}
+      };
+    }
+
+    return {
+      className: "text-foreground transition-colors duration-300 min-h-screen",
+      style: {
+        background: 'var(--background)',
+        color: 'var(--foreground)'
+      }
+    };
+  };
+
+  const getTitleStyles = () => {
+    if (theme === 'vanilla') {
+      return {
+        className: "text-4xl md:text-6xl font-bold mb-8 text-transparent bg-clip-text bg-gradient-to-r from-orange-600 to-amber-600 dark:from-red-500 dark:to-red-700",
+        style: {}
+      };
+    }
+
+    return {
+      className: "text-4xl md:text-6xl font-bold mb-8",
+      style: { color: 'var(--x-color)' }
+    };
+  };
+
+  const getResetButtonStyles = () => {
+    if (theme === 'vanilla') {
+      return {
+        className: "px-6 py-3 bg-gradient-to-r from-orange-500 to-amber-500 dark:from-red-800 dark:to-red-500 text-white rounded-lg text-lg font-semibold shadow-lg hover:from-orange-600 hover:to-amber-600 dark:hover:from-red-500 dark:hover:to-red-800 transition-colors duration-300",
+        style: {}
+      };
+    }
+
+    return {
+      className: "px-6 py-3 rounded-lg text-lg font-semibold shadow-lg transition-colors duration-300",
+      style: {
+        backgroundColor: 'var(--board-bg)',
+        color: 'var(--foreground)',
+        border: '1px solid var(--square-border)'
+      }
+    };
+  };
+
+  const containerStyles = getContainerStyles();
+  const titleStyles = getTitleStyles();
+  const resetButtonStyles = getResetButtonStyles();
+
   return (
     <div className="min-h-screen">
-      <div className="bg-gradient-to-br from-orange-300 via-amber-300 to-yellow-400 dark:from-[#0a192f] dark:via-[#0a192f] dark:to-[#112240] text-gray-900 dark:text-gray-100 transition-colors duration-300 min-h-screen">
+      <div className={containerStyles.className} style={containerStyles.style}>
         <div className="container mx-auto px-4 py-8 flex flex-col items-center justify-center min-h-screen">
           <motion.h1
-            className="text-4xl md:text-6xl font-bold mb-8 text-transparent bg-clip-text bg-gradient-to-r from-orange-600 to-amber-600 dark:from-red-500 dark:to-red-700"
+            className={titleStyles.className}
+            style={titleStyles.style}
             initial={{ y: -50, opacity: 0 }}
             animate={{ y: 0, opacity: 1 }}
           >
@@ -126,20 +170,12 @@ const TicTacToe = () => {
 
           <motion.button
             onClick={resetGame}
-            className="px-6 py-3 bg-gradient-to-r from-orange-500 to-amber-500 dark:from-red-800 dark:to-red-500 text-white rounded-lg text-lg font-semibold shadow-lg hover:from-orange-600 hover:to-amber-600 dark:hover:from-red-500 dark:hover:to-red-800 transition-colors duration-300"
+            className={resetButtonStyles.className}
+            style={resetButtonStyles.style}
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
           >
             Reset Game
-          </motion.button>
-
-          <motion.button
-            onClick={toggleTheme}
-            className="mt-4 p-2 rounded-full bg-gray-200 dark:bg-gray-800 text-gray-800 dark:text-gray-200"
-            whileHover={{ scale: 1.1 }}
-            whileTap={{ scale: 0.9 }}
-          >
-            {isDarkMode ? <Sun size={24} /> : <Moon size={24} />}
           </motion.button>
         </div>
       </div>

--- a/client/public/nature-bg.svg
+++ b/client/public/nature-bg.svg
@@ -1,0 +1,11 @@
+<svg width="100%" height="100%" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <pattern id="leaves" x="0" y="0" width="20" height="20" patternUnits="userSpaceOnUse">
+      <path d="M10,2 Q15,7 10,12 Q5,7 10,2" fill="#4a7c4a" opacity="0.1">
+        <animate attributeName="opacity" values="0.1;0.2;0.1" dur="3s" repeatCount="indefinite" />
+      </path>
+    </pattern>
+  </defs>
+  <rect width="100%" height="100%" fill="#e6f0e6"/>
+  <rect width="100%" height="100%" fill="url(#leaves)"/>
+</svg> 


### PR DESCRIPTION
## Description
Added a theme system to the Tic-Tac-Toe game that allows switching between different visual themes using URL parameters.

Closes #101 

### Features Added
- Multiple theme support:
  - Vanilla (default): Original light/dark theme
  - Dark: Dark mode with high contrast
  - Neon: Cyberpunk-style theme with neon colors
  - Nature: Organic theme with natural colors

- Theme switching via URL parameter:
  - `/play` or `/play?theme=vanilla` - Default theme
  - `/play?theme=dark` - Dark theme
  - `/play?theme=neon` - Neon theme
  - `/play?theme=nature` - Nature theme

### Technical Changes
- Added ThemeProvider component for theme state management
- Implemented CSS variables for theme-specific colors and styles
- Updated components to support themed styling:
  - GameBoard
  - Square
  - GameStatus
- Added SVG background for nature theme
- Removed visual theme selector while maintaining URL parameter functionality

### Testing
To test the changes:
1. Start the application
2. Visit different URLs to test each theme:
   - `/play` (default vanilla theme)
   - `/play?theme=dark`
   - `/play?theme=neon`
   - `/play?theme=nature`
3. Verify that all game functionality works correctly in each theme
4. Check that the themes persist through game restarts

### Screenshots
https://github.com/user-attachments/assets/44a4810b-5a9a-423f-8242-9cd956f1264e

