### PR TITLE
Revamp the board from 3x3 to 9x9

### DIFF
--- a/client/app/play/components/GameBoard.tsx
+++ b/client/app/play/components/GameBoard.tsx
@@ -15,13 +15,13 @@ const GameBoard: React.FC<GameBoardProps> = ({ squares, onClick, winner }) => {
   const getBoardStyles = () => {
     if (theme === 'vanilla') {
       return {
-        className: "grid grid-cols-3 gap-2 mb-8",
+        className: "grid grid-cols-9 gap-1 mb-8",
         style: {}
       };
     }
 
     return {
-      className: "grid grid-cols-3 gap-2 mb-8 p-4 rounded-lg",
+      className: "grid grid-cols-9 gap-1 mb-8 p-4 rounded-lg",
       style: {
         backgroundColor: 'var(--board-bg)',
         boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)'

--- a/client/app/play/components/Square.tsx
+++ b/client/app/play/components/Square.tsx
@@ -14,7 +14,7 @@ const Square: React.FC<SquareProps> = ({ value, onClick, winningSquare }) => {
   const getSquareStyles = () => {
     if (theme === 'vanilla') {
       return {
-        className: `w-20 h-20 md:w-24 md:h-24 border-4 text-4xl font-bold flex items-center justify-center rounded-lg shadow-lg ${
+        className: `w-8 h-8 md:w-10 md:h-10 border-2 text-lg font-bold flex items-center justify-center rounded-md shadow-md ${
           winningSquare
             ? "bg-yellow-300 border-yellow-500 text-orange-700 dark:bg-gray-900 dark:border-slate-300 dark:text-orange-200"
             : "bg-white border-orange-500 hover:bg-orange-100 dark:bg-[#0a192f] dark:border-red-700 dark:hover:bg-gray-800"
@@ -24,12 +24,12 @@ const Square: React.FC<SquareProps> = ({ value, onClick, winningSquare }) => {
     }
 
     return {
-      className: "w-20 h-20 md:w-24 md:h-24 text-4xl font-bold flex items-center justify-center rounded-lg",
+      className: "w-8 h-8 md:w-10 md:h-10 text-lg font-bold flex items-center justify-center rounded-md",
       style: {
         backgroundColor: winningSquare ? 'var(--hover-bg)' : 'var(--square-bg)',
-        border: `4px solid ${winningSquare ? 'var(--x-color)' : 'var(--square-border)'}`,
+        border: `2px solid ${winningSquare ? 'var(--x-color)' : 'var(--square-border)'}`,
         color: 'var(--foreground)',
-        boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)'
+        boxShadow: '0 2px 3px -1px rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.06)'
       }
     };
   };
@@ -38,14 +38,14 @@ const Square: React.FC<SquareProps> = ({ value, onClick, winningSquare }) => {
     if (theme === 'vanilla') {
       return {
         className: value === "X"
-          ? "text-blue-600 dark:text-blue-400"
-          : "text-red-600 dark:text-red-400",
+          ? "text-blue-600 dark:text-blue-400 text-sm md:text-base"
+          : "text-red-600 dark:text-red-400 text-sm md:text-base",
         style: {}
       };
     }
 
     return {
-      className: "",
+      className: "text-sm md:text-base",
       style: {
         color: value === 'X' ? 'var(--x-color)' : 'var(--o-color)'
       }

--- a/client/app/play/page.tsx
+++ b/client/app/play/page.tsx
@@ -9,7 +9,7 @@ import { useTheme } from '../components/ThemeProvider';
 
 const TicTacToe = () => {
   const [squares, setSquares] = useState<(string | null)[]>(
-    Array(9).fill(null)
+    Array(81).fill(null)
   );
   const [xIsNext, setXIsNext] = useState(true);
   const [xScore, setXScore] = useState(0);
@@ -18,24 +18,51 @@ const TicTacToe = () => {
   const { theme } = useTheme();
 
   const calculateWinner = (squares: (string | null)[]) => {
-    const lines = [
-      [0, 1, 2],
-      [3, 4, 5],
-      [6, 7, 8],
-      [0, 3, 6],
-      [1, 4, 7],
-      [2, 5, 8],
-      [0, 4, 8],
-      [2, 4, 6],
-    ];
+    // Rows
+    const lines = [];
+    
+    // Horizontal lines (rows)
+    for (let row = 0; row < 9; row++) {
+      for (let col = 0; col <= 4; col++) {
+        const start = row * 9 + col;
+        lines.push([start, start + 1, start + 2, start + 3, start + 4]);
+      }
+    }
+    
+    // Vertical lines (columns)
+    for (let col = 0; col < 9; col++) {
+      for (let row = 0; row <= 4; row++) {
+        const start = row * 9 + col;
+        lines.push([start, start + 9, start + 18, start + 27, start + 36]);
+      }
+    }
+    
+    // Diagonal lines (top-left to bottom-right)
+    for (let row = 0; row <= 4; row++) {
+      for (let col = 0; col <= 4; col++) {
+        const start = row * 9 + col;
+        lines.push([start, start + 10, start + 20, start + 30, start + 40]);
+      }
+    }
+    
+    // Diagonal lines (top-right to bottom-left)
+    for (let row = 0; row <= 4; row++) {
+      for (let col = 4; col < 9; col++) {
+        const start = row * 9 + col;
+        lines.push([start, start + 8, start + 16, start + 24, start + 32]);
+      }
+    }
 
-    for (const [a, b, c] of lines) {
+    for (const line of lines) {
+      const [a, b, c, d, e] = line;
       if (
         squares[a] &&
         squares[a] === squares[b] &&
-        squares[a] === squares[c]
+        squares[a] === squares[c] &&
+        squares[a] === squares[d] &&
+        squares[a] === squares[e]
       ) {
-        return { winner: squares[a], line: [a, b, c] };
+        return { winner: squares[a], line: [a, b, c, d, e] };
       }
     }
     return null;
@@ -66,7 +93,7 @@ const TicTacToe = () => {
   };
 
   const resetGame = () => {
-    setSquares(Array(9).fill(null));
+    setSquares(Array(81).fill(null));
     setXIsNext(true);
     setShowWinnerAlert(null);
   };
@@ -140,15 +167,19 @@ const TicTacToe = () => {
   return (
     <div className="min-h-screen">
       <div className={containerStyles.className} style={containerStyles.style}>
-        <div className="container mx-auto px-4 py-8 flex flex-col items-center justify-center min-h-screen">
+        <div className="container mx-auto px-4 py-4 flex flex-col items-center justify-center min-h-screen">
           <motion.h1
             className={titleStyles.className}
             style={titleStyles.style}
             initial={{ y: -50, opacity: 0 }}
             animate={{ y: 0, opacity: 1 }}
           >
-            Tic Tac Toe
+            Tic Tac Toe 9x9
           </motion.h1>
+
+          <p className="text-center mb-4 text-sm md:text-base">
+            Get 5 in a row to win!
+          </p>
 
           <GameBoard 
             squares={squares} 


### PR DESCRIPTION
Updated game board from 3x3 to 9x9 grid (81 squares)
Updated win condition to require 5 in a row
Adjusted UI components to fit the larger board
Added instruction text for players

Image:  
<img width="1195" alt="tiktactoe" src="https://github.com/user-attachments/assets/2b4e4a94-d330-4d6e-9b10-02b74c3a77bf" />

Closes #102 